### PR TITLE
Minor English tweak in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Resizer 
 
 Resizer is an http image resizer. It uses magickwand to resize images on the fly.
-Source images are obtained from an upstream (file/http). They can optionally be cached to a downstram (file/s3).
+Source images are obtained from an upstream (file/http). They can optionally be cached to a downstream (file/s3).
 
 ## Getting Started
 


### PR DESCRIPTION
Found a spelling mistake - `downstram` > `downstream`
